### PR TITLE
Currency icon image sizing fix.

### DIFF
--- a/src/common/index.scss
+++ b/src/common/index.scss
@@ -336,8 +336,8 @@
 .nitro-currency-icon {
     background-position: center;
     background-repeat: no-repeat;
-    width: 15px;
-    height: 15px;
+    width: 21px;
+    height: 20px;
 }
 
 .nitro-item-count {


### PR DESCRIPTION
If using official Habbo's currency icons this fixes the images sizes width and height. https://ibb.co/ChzCLQN