### PR TITLE
Updates to the following - HotelView, UserProfileView, Navigator.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -31,7 +31,7 @@ $inventory-width: 490px;
 $inventory-height: 315px;
 
 $navigator-width: 425px;
-$navigator-height: 560px;
+$navigator-height: 500px;
 $navigator-min-height: 205px;
 
 $nitro-room-creator-width: 585px;
@@ -41,7 +41,7 @@ $chat-input-style-selector-widget-width: 210px;
 $chat-input-style-selector-widget-height: 500px;
 
 $user-profile-width: 470px;
-$user-profile-height: 460px;
+$user-profile-height: 538px;
 
 $nitro-widget-custom-stack-height-width: 275px;
 $nitro-widget-custom-stack-height-height: 220px;

--- a/src/components/hotel-view/HotelView.scss
+++ b/src/components/hotel-view/HotelView.scss
@@ -2,7 +2,7 @@
     display: block;
 	position: fixed;
 	width: 100%;
-	height: calc(100% - 55px);
+	height: calc(100% - 51px);
 	background: rgba($black, 1);
 	color:#fff;
 	

--- a/src/components/user-profile/UserProfileVew.scss
+++ b/src/components/user-profile/UserProfileVew.scss
@@ -1,7 +1,6 @@
 .user-profile {
     width: $user-profile-width;
-    min-height: $user-profile-height;
-    max-height: 515px;
+    height: $user-profile-height;
     color: $black;
     resize: none;
 


### PR DESCRIPTION
Updates to the following -

Hotel View: 
We are moving the images down 4 pixels to compensate for the bottom bar being adjusted for 4 pixels shorter. 
Thus removing the 4 pixel black gap in-between the bottom bar the hotel view images.

User Profile View: 
Is now correctly at its set height. Had to remove the "min/max height" class as it had limitations that wouldn't let it reach its proper height, so we added just a "height" class and it allows us to reach our desired height.

Navigator:
Corrected the height of the Navigator, the navigator was over by about 60 pixels in height.
