### PR TITLE
Update CatalogLayoutGuildFrontpageView.tsx

### DIFF
--- a/src/components/catalog/views/page/layout/CatalogLayoutGuildFrontpageView.tsx
+++ b/src/components/catalog/views/page/layout/CatalogLayoutGuildFrontpageView.tsx
@@ -16,14 +16,13 @@ export const CatalogLayouGuildFrontpageView: FC<CatalogLayoutProps> = props =>
         <Column>
             <Column gap={ 4 } overflow="hidden" className="p-3">
                 <Text bold dangerouslySetInnerHTML={ { __html: page.localization.getText(2) } } />
-                <Text overflow="auto" dangerouslySetInnerHTML={ { __html: page.localization.getText(0) } } />
                 <Text dangerouslySetInnerHTML={ { __html: page.localization.getText(1) } } />
             </Column>
             <Column center size={ 5 } overflow="hidden">
-                <LayoutImage imageUrl={ page.localization.getImage(1) } />
                 <Button onClick={ () => CreateLinkEvent('groups/create') }>
                     { LocalizeText('catalog.start.guild.purchase.button') }
                 </Button>
+                <LayoutImage imageUrl={ page.localization.getImage(1) } />
             </Column>
         </Column>
     );


### PR DESCRIPTION
Fixed a few issues with this page and made it more like Habbo. It was printing off the header text into the body thus pushing the content so far down it goes out of the catalog container. The button was also under the image it needed to be above it.

The image illustrates the following -
Left Image: FlashUI Before
Right Image: FlashUI After

https://i.ibb.co/k4xHShp/groups.png