### PR TITLE
Update index.scss

### DIFF
--- a/src/common/index.scss
+++ b/src/common/index.scss
@@ -336,8 +336,8 @@
 .nitro-currency-icon {
     background-position: center;
     background-repeat: no-repeat;
-    width: 15px;
-    height: 15px;
+    width: 16px;
+    height: 16px;
 }
 
 .nitro-item-count {


### PR DESCRIPTION
Fixed the sized HC icon located in various places within the UI.

The image illustrates the follow -
Before - Left
After - Right

https://i.ibb.co/nPy5fJj/hcicon.png

This update will break the currency view in the purse, we will need to update that. This is the only solution, so fixing the currency view in the purse is necessary following this push.